### PR TITLE
fix: handle stateNode.on transitions being stateNode objects as well as strings

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -4,9 +4,11 @@ const Buffer = require('./buffer');
 const isStateNode = machine => machine.constructor.name === 'StateNode';
 
 const resolvePath = (stateNode, path) =>
-  path[0] === '#'
-    ? stateNode.getStateNodeById(path).id
-    : stateNode.getStateNodeByPath(path).id;
+  typeof path === 'object' ? 
+    path.id : 
+    path[0] === '#'
+      ? stateNode.getStateNodeById(path).id
+      : stateNode.getStateNodeByPath(path).id;
 
 const iterateTransitions = stateNode => {
   if(!stateNode) {


### PR DESCRIPTION
Closes #33 

xstate as of 4.7.0 now returns transition targets as the entire stateNode object, rather than just the id string. This was causing `resolvePath` to fail, as it only ever expected a string rather than the full stateNode