### PR TITLE
fix: Handle case when `cond` is an object

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -25,7 +25,7 @@ const iterateTransitions = stateNode => {
 }
 
 const normalizeStringArray = array => {
-  if (!array || !array.length) {
+  if (!array) {
     return [];
   }
 


### PR DESCRIPTION
In the case of a state machine like the following:

```
{
  "initial": "initial",
  "states": {
    "initial": {
      "on": {
        "": {
          "target": "final",
          "cond: {"type":"xstate.guard","name":"check"}
        }
      }
    },
    "final": {
      "final": true
    }
  }
}
```

The [resulting plantuml has a syntax error](https://codesandbox.io/s/admiring-goodall-i93cw?file=/src/machine.json)

PS: those kind of objects are created by xstate in recent versions when just setting a cond.
PPS: The syntax error only happens in combination with using the [null events](https://xstate.js.org/docs/guides/events.html#null-events) since in that case nothing is present behind the `:`, but even when it's a normal event the guard wouldn't be shown on the transition.