### PR TITLE
fix: Handle actions that are objects

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -30,7 +30,7 @@ const normalizeStringArray = array => {
   }
 
   array = Array.isArray(array) ? array : [array];
-  return array.map(e => (typeof e === 'string' ? e : e.name));
+  return array.map(e => (typeof e === 'string' ? e : e.name || e.type));
 };
 
 const transitionGuards = cond => {
@@ -68,12 +68,20 @@ const activities = (stateNode, buffer) => {
 };
 
 const internalActions = (stateNode, buffer) => {
-  for (const action of stateNode.onEntry) {
-    buffer.appendf`${stateNode.id} : onEntry/${action}`;
+  if (stateNode.onEntry) {
+    normalizeStringArray(stateNode.onEntry).forEach(
+      (action) => {
+        buffer.appendf`${stateNode.id} : onEntry/${action}`
+      }
+    )
   }
 
-  for (const action of stateNode.onExit) {
-    buffer.appendf`${stateNode.id} : onExit/${action}`;
+  if (stateNode.onExit) {
+    normalizeStringArray(stateNode.onExit).forEach(
+      (action) => {
+        buffer.appendf`${stateNode.id} : onExit/${action}`
+      }
+    )
   }
 };
 


### PR DESCRIPTION
With the following [machine config](https://codesandbox.io/s/xenodochial-flower-326hw?file=/src/machine.json):

```
{
  "initial": "initial",
  "states": {
    "initial": {
      "on": {
        "T": {
          "target": "final",
          "actions": [{ "type": "myAction" }]
        }
      }
    },
    "final": {
      "entry": [{ "type": "finalAction" }],
      "final": true
    }
  }
}
```

the actions are not part of the output. Those kind of objects are created by latest XState when just passing a string.